### PR TITLE
ライブラリの依存関係のバージョンの見直し

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Apache2 License
 ## Dependency
 
 - Java 11+
-- SpringFramework 5.1+
+- SpringFramework 5.0+
 - Slf4j 1.7+
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 	<properties>
 		<java.version>11</java.version>
 		<source.encode>UTF-8</source.encode>
-		<spring.version>5.1.6.RELEASE</spring.version>
+		<spring.version>5.0.18.RELEASE</spring.version>
 		<slf4j.version>1.7.25</slf4j.version>
 		<logback.version>1.2.3</logback.version>
 		<jacoco.include.package>com.github.mygreen.splate.*</jacoco.include.package>


### PR DESCRIPTION
ライブラリの依存関係の見直し。
使いやすいように、できるだけ低いバージョンにする。

- Java : 11 (変更なし)
  - OpenJDK 8はサポートは2023～2026年までとまだ先だが、OpenJDK11もLTSで、さすがに11でもよいのでは。
- SpringFramework : 5.1 -> 5.0