### PR TITLE
エラー発生時のテンプレートの位置などを詳細に出す

### DIFF
--- a/src/main/java/com/github/mygreen/splate/Position.java
+++ b/src/main/java/com/github/mygreen/splate/Position.java
@@ -1,0 +1,30 @@
+package com.github.mygreen.splate;
+
+import lombok.Data;
+
+/**
+ * テンプレートの位置情報を表す
+ *
+ * @since 0.2
+ * @author T.TSUCHIE
+ *
+ */
+@Data
+public class Position {
+
+    /**
+     * 行（1から始まる）
+     */
+    private int row;
+
+    /**
+     * 列（1から始まる）
+     */
+    private int col;
+
+    /**
+     * 行の文字列
+     */
+    private String line;
+
+}

--- a/src/main/java/com/github/mygreen/splate/Position.java
+++ b/src/main/java/com/github/mygreen/splate/Position.java
@@ -1,6 +1,8 @@
 package com.github.mygreen.splate;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * テンプレートの位置情報を表す
@@ -9,6 +11,8 @@ import lombok.Data;
  * @author T.TSUCHIE
  *
  */
+@NoArgsConstructor
+@AllArgsConstructor
 @Data
 public class Position {
 

--- a/src/main/java/com/github/mygreen/splate/ProcessResult.java
+++ b/src/main/java/com/github/mygreen/splate/ProcessResult.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * SQLテンプレートを実行した結果
+ * SQLテンプレートを評価した結果
  *
  * @author T.TSUCHIE
  *
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 public class ProcessResult {
 
     /**
-     * SQL
+     * 評価されたSQL
      */
     @Getter
     private final String sql;

--- a/src/main/java/com/github/mygreen/splate/SqlTemplate.java
+++ b/src/main/java/com/github/mygreen/splate/SqlTemplate.java
@@ -18,6 +18,13 @@ import lombok.RequiredArgsConstructor;
 public class SqlTemplate {
 
     /**
+     * パースされたSQL。
+     * <p>正規化によりトリムや最後のセミコロン({@literal ;})が削除されたものです。</p>
+     */
+    @Getter
+    private final String sql;
+
+    /**
      * SQLノード
      */
     @Getter
@@ -32,10 +39,11 @@ public class SqlTemplate {
     public ProcessResult process(final SqlTemplateContext templateContext) {
 
         final NodeProcessContext processContext = new NodeProcessContext(templateContext);
+        processContext.setParsedSql(sql);
 
         // SQLテンプレートを評価します。
         node.accept(processContext);
 
-        return new ProcessResult(processContext.getSql(), processContext.getBindParams());
+        return new ProcessResult(processContext.getProcessedSql(), processContext.getBindParams());
     }
 }

--- a/src/main/java/com/github/mygreen/splate/SqlTemplateEngine.java
+++ b/src/main/java/com/github/mygreen/splate/SqlTemplateEngine.java
@@ -147,10 +147,15 @@ public class SqlTemplateEngine {
 
     }
 
+    /**
+     * 文字列で指定されたSQLテンプレートをパースします。
+     * @param sql SQL
+     * @return パース結果。
+     */
     private SqlTemplate parseTemplateByText(final String sql) {
         SqlParser parser = createSqlParser(sql);
         Node node = parser.parse();
-        return new SqlTemplate(node);
+        return new SqlTemplate(parser.getSql(), node);
     }
 
     /**

--- a/src/main/java/com/github/mygreen/splate/SqlUtils.java
+++ b/src/main/java/com/github/mygreen/splate/SqlUtils.java
@@ -5,12 +5,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * 2Way-SQL機能の中で提供されるユーティリティクラス。
  * <p>MirageSQL/Seaser2からの持ち込みなので、既存のユーティリティクラスとは分けて定義する。</p>
  *
- *
+ * @version 0.2
  * @author T.TSUCHIE
  *
  */
@@ -122,5 +123,133 @@ public class SqlUtils {
             throw new IllegalArgumentException("not such algorithm name " + algorithm, e);
         }
 
+    }
+
+    /**
+     * SQL中の位置として行、列の位置を解決します。
+     * @param sql SQL
+     * @param position 位置
+     * @return テンプレートの位置情報
+     */
+    public static Position resolveSqlPosition(final String sql, final int position) {
+
+        // 現在の位置より前の情報を切り出し、改行を検索する。
+        final String before = sql.substring(0, position);
+
+        int row = 1;
+
+        final String[] searchWords = {"\r\n", "\r", "\n"};
+
+        AtomicReference<CharSequence> foundStr = new AtomicReference<>();
+        int lastIndex = 0;
+        int index = 0;
+        while((index = indexOfAny(before, index, foundStr, searchWords)) >= 0) {
+            // 改行が見つかったら行数をカウントアップする。
+            row++;
+
+            index += foundStr.get().length();
+
+            // 現在見つかっている改行の位置を保持しておく
+            lastIndex = index;
+        }
+
+        // 最後に改行が見つかった位置から、SQLの位置を引けば列がわかる
+        int col = position - lastIndex;
+        if(lastIndex > 0) {
+            col--;
+        }
+
+        // 行の切り出し
+        final String after = sql.substring(lastIndex);
+        String line = after;
+        if((index = indexOfAny(after, 0, null, searchWords)) >= 0) {
+            line = after.substring(0, index);
+        }
+
+        final Position result = new Position();
+        result.setCol(col);
+        result.setRow(row);
+        result.setLine(line);
+
+        return result;
+
+    }
+
+    /**
+     * <p>指定した複数の文字列から、最初に出現する位置のインデックスを返します。</p>
+     * <p>CommonsLangの{@code StringUtils#indexOfAny}の持ち込み。</p>
+     *
+     * <ul>
+     *   <li>検索対象の文字が {@code null}の場合は、{@code -1} を返します。</li>
+     *   <li>検索文字が {@code null} または空の配列の場合は、{@code -1} を返します。</li>
+     *   <li>検索文字に 空文字({@code ""})が含まれる場合、{@code 0}を返します。</li>
+     *   <li></li>
+     * </ul>
+     *
+     * @param str 検索対象の文字列
+     * @param startPos 検索開始する位置。0から始まります。
+     * @param foundStr 見つかった文字列。見つかった場合には値がセットされます。{@code null}の場合は値はセットされません。
+     * @param searchStrs  検索する文字列
+     * @return 初めに見つかった文字列のインデクスを返します。見つからない場合は、{@code -1}を返します。
+     * @since 0.2
+     */
+    public static int indexOfAny(final CharSequence str, final int startPos,
+            final AtomicReference<CharSequence> foundStr, final CharSequence... searchStrs) {
+
+        if (str == null || searchStrs == null || searchStrs.length == 0) {
+            return INDEX_NOT_FOUND;
+        }
+
+        // String's can't have a MAX_VALUEth index.
+        int ret = Integer.MAX_VALUE;
+
+        int tmp = 0;
+        for (final CharSequence search : searchStrs) {
+            if (search == null) {
+                continue;
+            }
+            tmp = indexOf(str, search, startPos);
+            if (tmp == INDEX_NOT_FOUND) {
+                continue;
+            }
+
+            if (tmp < ret) {
+                ret = tmp;
+
+                // 見つかった文字列を保存する
+                if(foundStr != null) {
+                    foundStr.set(search);
+                }
+            }
+        }
+
+        return ret == Integer.MAX_VALUE ? INDEX_NOT_FOUND : ret;
+    }
+
+    /**
+     * 文字列の位置検索で失敗したときの値.
+     * @since 0.2
+     */
+    private static final int INDEX_NOT_FOUND = -1;
+
+    /**
+     * {@link CharSequence}に対する {@code indexOf(CharSequence)}の実装。
+     * <p>CommonsLangの{@code CharSequenceUtils#indexOf}の持ち込み。</p>
+     *
+     * @param cs the {@code CharSequence} to be processed
+     * @param searchChar the {@code CharSequence} to be searched for
+     * @param start the start index
+     * @return the index where the search sequence was found
+     * @since 0.2
+     */
+    private static int indexOf(final CharSequence cs, final CharSequence searchChar, final int start) {
+        if (cs instanceof String) {
+            return ((String) cs).indexOf(searchChar.toString(), start);
+        } else if (cs instanceof StringBuilder) {
+            return ((StringBuilder) cs).indexOf(searchChar.toString(), start);
+        } else if (cs instanceof StringBuffer) {
+            return ((StringBuffer) cs).indexOf(searchChar.toString(), start);
+        }
+        return cs.toString().indexOf(searchChar.toString(), start);
     }
 }

--- a/src/main/java/com/github/mygreen/splate/node/AbstractNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/AbstractNode.java
@@ -18,10 +18,20 @@ package com.github.mygreen.splate.node;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.EvaluationException;
+import org.springframework.expression.Expression;
+
+import com.github.mygreen.splate.SqlUtils;
+import com.github.mygreen.splate.type.SqlTemplateValueType;
+import com.github.mygreen.splate.type.SqlTypeConversionException;
+import com.github.mygreen.splate.type.TextConversionException;
+
 /**
- * <code>Node</code>の抽象クラスです。
+ * {@link Node}の抽象クラスです。
  *
  * @author higa
+ * @author T.TSUCHIE
  *
  */
 public abstract class AbstractNode implements Node {
@@ -32,9 +42,17 @@ public abstract class AbstractNode implements Node {
     protected List<Node> children = new ArrayList<>();
 
     /**
-     * <code>AbstractNode</code>を作成します。
+     * テンプレート内での位置情報
      */
-    public AbstractNode() {
+    protected final int position;
+
+    /**
+     * コンストラクタ
+     *
+     * @param position テンプレート内での位置
+     */
+    public AbstractNode(final int position) {
+        this.position = position;
     }
 
     @Override
@@ -51,4 +69,94 @@ public abstract class AbstractNode implements Node {
     public void addChild(Node node) {
         children.add(node);
     }
+
+    @Override
+    public int getPosition() {
+        return position;
+    }
+
+    /**
+     * EL式を評価します。
+     * <p>例外処理を含めて共通化のために切り出したメソッドです。</p>
+     *
+     * @param <T> 戻り値のタイプ
+     * @param expression EL式
+     * @param evaluationContext EL式のコンテキスト
+     * @param requriedType EL式の戻り値
+     * @param position テンプレートの位置情報
+     * @param parsedSql パース済みのSQLテンプレート
+     * @return EL式の評価結果
+     */
+    protected <T> T evaluateExpression(final Expression expression, final EvaluationContext evaluationContext,
+            final Class<T> requriedType, final int position, final String parsedSql) {
+
+        try {
+            return expression.getValue(evaluationContext, requriedType);
+        } catch(EvaluationException e) {
+            throw new NodeProcessException(SqlUtils.resolveSqlPosition(parsedSql, position),
+                    String.format("Fail evaluating expression '%s'.", expression.getExpressionString()),
+                    e);
+        }
+    }
+
+    /**
+     * 変換規則を元にバインド変数を変換します。
+     * <p>例外処理を含めて共通化のために切り出したメソッドです。</p>
+     * <p>変換規則がnullの場合は、変換対象の値をそのまま返します。</p>
+     *
+     * @param value 変換対象の値。
+     * @param valueType 変換規則
+     * @param position テンプレートの位置情報
+     * @param parsedSql パース済みのSQLテンプレート
+     * @param expression 変換対象の値の元となったEL式
+     * @return 変換した値。
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected Object getBindBariableValue(final Object value, SqlTemplateValueType valueType,
+            final int position, final String parsedSql, final String expression) {
+
+        if(valueType == null) {
+            return value;
+        }
+
+        try {
+            return valueType.getBindVariableValue(value);
+        } catch(SqlTypeConversionException e) {
+            throw new NodeProcessException(SqlUtils.resolveSqlPosition(parsedSql, position),
+                    String.format("Fail converting value of expression '%s'.", expression),
+                    e);
+        }
+
+    }
+
+    /**
+     * 変換規則を元に埋め込み変数を変換します。
+     * <p>例外処理を含めて共通化のために切り出したメソッドです。</p>
+     * <p>変換規則がnullの場合は、変換対象の値をそのまま返します。</p>
+     *
+     * @param value 変換対象の値。
+     * @param valueType 変換規則
+     * @param position テンプレートの位置情報
+     * @param parsedSql パース済みのSQLテンプレート
+     * @param expression 変換対象の値の元となったEL式
+     * @return 変換した値。
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected String getEmbeddedValue(final Object value, SqlTemplateValueType valueType,
+            final int position, final String parsedSql, final String expression) {
+
+        if(valueType == null) {
+            return value.toString();
+        }
+
+        try {
+            return valueType.getEmbeddedValue(value);
+        } catch(TextConversionException e) {
+            throw new NodeProcessException(SqlUtils.resolveSqlPosition(parsedSql, position),
+                    String.format("Fail converting value of expression '%s'.", expression),
+                    e);
+        }
+
+    }
+
 }

--- a/src/main/java/com/github/mygreen/splate/node/AbstractNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/AbstractNode.java
@@ -30,6 +30,7 @@ import com.github.mygreen.splate.type.TextConversionException;
 /**
  * {@link Node}の抽象クラスです。
  *
+ * @version 0.2
  * @author higa
  * @author T.TSUCHIE
  *

--- a/src/main/java/com/github/mygreen/splate/node/AbstractNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/AbstractNode.java
@@ -79,6 +79,7 @@ public abstract class AbstractNode implements Node {
      * EL式を評価します。
      * <p>例外処理を含めて共通化のために切り出したメソッドです。</p>
      *
+     * @since 0.2
      * @param <T> 戻り値のタイプ
      * @param expression EL式
      * @param evaluationContext EL式のコンテキスト
@@ -86,6 +87,7 @@ public abstract class AbstractNode implements Node {
      * @param position テンプレートの位置情報
      * @param parsedSql パース済みのSQLテンプレート
      * @return EL式の評価結果
+     * @throws NodeProcessException EL式の評価に失敗した場合にスローされます。
      */
     protected <T> T evaluateExpression(final Expression expression, final EvaluationContext evaluationContext,
             final Class<T> requriedType, final int position, final String parsedSql) {
@@ -104,12 +106,14 @@ public abstract class AbstractNode implements Node {
      * <p>例外処理を含めて共通化のために切り出したメソッドです。</p>
      * <p>変換規則がnullの場合は、変換対象の値をそのまま返します。</p>
      *
+     * @since 0.2
      * @param value 変換対象の値。
      * @param valueType 変換規則
      * @param position テンプレートの位置情報
      * @param parsedSql パース済みのSQLテンプレート
      * @param expression 変換対象の値の元となったEL式
      * @return 変換した値。
+     * @throws NodeProcessException 変換時の処理に失敗した場合にスローされます。
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     protected Object getBindBariableValue(final Object value, SqlTemplateValueType valueType,
@@ -134,12 +138,14 @@ public abstract class AbstractNode implements Node {
      * <p>例外処理を含めて共通化のために切り出したメソッドです。</p>
      * <p>変換規則がnullの場合は、変換対象の値をそのまま返します。</p>
      *
+     * @since 0.2
      * @param value 変換対象の値。
      * @param valueType 変換規則
      * @param position テンプレートの位置情報
      * @param parsedSql パース済みのSQLテンプレート
      * @param expression 変換対象の値の元となったEL式
      * @return 変換した値。
+     * @throws NodeProcessException 変換時の処理に失敗した場合にスローされます。
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     protected String getEmbeddedValue(final Object value, SqlTemplateValueType valueType,

--- a/src/main/java/com/github/mygreen/splate/node/AbstractNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/AbstractNode.java
@@ -116,7 +116,7 @@ public abstract class AbstractNode implements Node {
      * @throws NodeProcessException 変換時の処理に失敗した場合にスローされます。
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    protected Object getBindBariableValue(final Object value, SqlTemplateValueType valueType,
+    protected Object getBindVariableValue(final Object value, SqlTemplateValueType valueType,
             final int position, final String parsedSql, final String expression) {
 
         if(valueType == null) {

--- a/src/main/java/com/github/mygreen/splate/node/AddWhereIfNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/AddWhereIfNode.java
@@ -28,9 +28,10 @@ import org.springframework.core.style.ToStringCreator;
  */
 public class AddWhereIfNode extends ContainerNode {
 
-    private static Pattern pat = Pattern.compile("\\s*(order\\sby)|$)");
+    private static final Pattern PATTERN = Pattern.compile("\\s*(order\\sby)|$)", Pattern.CASE_INSENSITIVE);
 
-    public AddWhereIfNode() {
+    public AddWhereIfNode(final int position) {
+        super(position);
     }
 
     @Override
@@ -39,8 +40,8 @@ public class AddWhereIfNode extends ContainerNode {
         NodeProcessContext childCtx = new NodeProcessContext(ctx);
         super.accept(childCtx);
         if (childCtx.isEnabled()) {
-            String sql = childCtx.getSql();
-            Matcher m = pat.matcher(sql);
+            String sql = childCtx.getProcessedSql();
+            Matcher m = PATTERN.matcher(sql);
             if (!m.lookingAt()) {
                 sql = " WHERE " + sql;
             }
@@ -51,6 +52,7 @@ public class AddWhereIfNode extends ContainerNode {
     @Override
     public String toString() {
         return new ToStringCreator(this)
+                .append("position", getPosition())
                 .append("children", children)
                 .toString();
     }

--- a/src/main/java/com/github/mygreen/splate/node/BeginNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/BeginNode.java
@@ -25,7 +25,8 @@ import org.springframework.core.style.ToStringCreator;
  */
 public class BeginNode extends ContainerNode {
 
-    public BeginNode() {
+    public BeginNode(final int position) {
+        super(position);
     }
 
     @Override
@@ -33,13 +34,14 @@ public class BeginNode extends ContainerNode {
         NodeProcessContext childCtx = new NodeProcessContext(ctx);
         super.accept(childCtx);
         if (childCtx.isEnabled()) {
-            ctx.addSql(childCtx.getSql(), childCtx.getBindParams());
+            ctx.addSql(childCtx.getProcessedSql(), childCtx.getBindParams());
         }
     }
 
     @Override
     public String toString() {
         return new ToStringCreator(this)
+                .append("position", getPosition())
                 .append("children", children)
                 .toString();
     }

--- a/src/main/java/com/github/mygreen/splate/node/BindVariableNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/BindVariableNode.java
@@ -26,6 +26,7 @@ import lombok.Getter;
 /**
  * （コメントによる定義の）バインド変数のための{@link Node}です。
  *
+ * @version 0.2
  * @author higa
  * @author T.TSUCHIE
  */

--- a/src/main/java/com/github/mygreen/splate/node/BindVariableNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/BindVariableNode.java
@@ -63,7 +63,7 @@ public class BindVariableNode extends AbstractNode {
         Class<?> clazz = parsedExpression.getValueType(evaluationContext);
 
         SqlTemplateValueType<?> valueType = ctx.getValueTypeRegistry().findValueType(clazz, expression);
-        value = getBindBariableValue(value, valueType, getPosition(), ctx.getParsedSql(), expression);
+        value = getBindVariableValue(value, valueType, getPosition(), ctx.getParsedSql(), expression);
         ctx.addSql("?", value);
     }
 

--- a/src/main/java/com/github/mygreen/splate/node/BindVariableNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/BindVariableNode.java
@@ -18,7 +18,6 @@ package com.github.mygreen.splate.node;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
-import org.springframework.expression.ExpressionParser;
 
 import com.github.mygreen.splate.type.SqlTemplateValueType;
 
@@ -43,33 +42,35 @@ public class BindVariableNode extends AbstractNode {
      */
     private final Expression parsedExpression;
 
-
     /**
      * {@link BindVariableNode} を作成します。
      *
+     * @param position テンプレートの位置情報
      * @param expression 式
-     * @param expressionParser 式のパーサ
+     * @param parsedExpression パース済みの式
      */
-    public BindVariableNode(final String expression, final ExpressionParser expressionParser) {
+    public BindVariableNode(final int position, final String expression, final Expression parsedExpression) {
+        super(position);
         this.expression = expression;
-        this.parsedExpression = expressionParser.parseExpression(expression);
+        this.parsedExpression = parsedExpression;
     }
 
-    @SuppressWarnings("rawtypes")
     @Override
     public void accept(final NodeProcessContext ctx) {
 
-        EvaluationContext evaluationContext = ctx.getEvaluationContext();
-        Object value = parsedExpression.getValue(evaluationContext);
+        final EvaluationContext evaluationContext = ctx.getEvaluationContext();
+        Object value = evaluateExpression(parsedExpression, evaluationContext, Object.class, getPosition(), ctx.getParsedSql());
         Class<?> clazz = parsedExpression.getValueType(evaluationContext);
 
-        SqlTemplateValueType valueType = ctx.getValueTypeRegistry().findValueType(clazz, expression);
-        ctx.addSql("?", value, valueType);
+        SqlTemplateValueType<?> valueType = ctx.getValueTypeRegistry().findValueType(clazz, expression);
+        value = getBindBariableValue(value, valueType, getPosition(), ctx.getParsedSql(), expression);
+        ctx.addSql("?", value);
     }
 
     @Override
     public String toString() {
         return new ToStringCreator(this)
+                .append("position", getPosition())
                 .append("expression", expression)
                 .append("parsedExpression", parsedExpression)
                 .append("children", children)

--- a/src/main/java/com/github/mygreen/splate/node/ContainerNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/ContainerNode.java
@@ -24,7 +24,8 @@ import org.springframework.core.style.ToStringCreator;
  */
 public class ContainerNode extends AbstractNode {
 
-    public ContainerNode() {
+    public ContainerNode(final int position) {
+        super(position);
     }
 
     @Override
@@ -37,6 +38,7 @@ public class ContainerNode extends AbstractNode {
     @Override
     public String toString() {
         return new ToStringCreator(this)
+                .append("position", getPosition())
                 .append("children", children)
                 .toString();
     }

--- a/src/main/java/com/github/mygreen/splate/node/ElseNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/ElseNode.java
@@ -21,10 +21,12 @@ import org.springframework.core.style.ToStringCreator;
  * {@code ELSE} コメント用の{@link Node}です。
  *
  * @author higa
+ * @author T.TSUCHIE
  */
 public class ElseNode extends ContainerNode {
 
-    public ElseNode() {
+    public ElseNode(final int position) {
+        super(position);
     }
 
     @Override
@@ -36,6 +38,7 @@ public class ElseNode extends ContainerNode {
     @Override
     public String toString() {
         return new ToStringCreator(this)
+                .append("position", getPosition())
                 .append("children", children)
                 .toString();
     }

--- a/src/main/java/com/github/mygreen/splate/node/EmbeddedValueNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/EmbeddedValueNode.java
@@ -18,9 +18,8 @@ package com.github.mygreen.splate.node;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
-import org.springframework.expression.ExpressionParser;
 
-import com.github.mygreen.splate.TwoWaySqlException;
+import com.github.mygreen.splate.SqlUtils;
 import com.github.mygreen.splate.type.SqlTemplateValueType;
 
 import lombok.Getter;
@@ -43,32 +42,34 @@ public class EmbeddedValueNode extends AbstractNode {
     private final Expression parsedExpression;
 
     /**
-     * Creates a <code>EmbeddedValueNode</code> from a string expression.
+     * {@link EmbeddedValueNode}のインスタンスを作成します。.
      *
+     * @param position 位置情報
      * @param expression 式
-     * @param expressionParser 式のパーサ
+     * @param parsedExpression パース済みの式
      */
-    public EmbeddedValueNode(String expression, final ExpressionParser expressionParser) {
+    public EmbeddedValueNode(final int position, final String expression, final Expression parsedExpression) {
+        super(position);
         this.expression = expression;
-        this.parsedExpression = expressionParser.parseExpression(expression);
+        this.parsedExpression = parsedExpression;
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void accept(final NodeProcessContext ctx) {
 
         EvaluationContext evaluationContext = ctx.getEvaluationContext();
-        Object value = parsedExpression.getValue(evaluationContext);
+        Object value = evaluateExpression(parsedExpression, evaluationContext, Object.class, getPosition(), ctx.getParsedSql());
 
         if (value != null) {
             // SQLファイルに埋め込むために、文字列に変換する。
-            Class<?> clazz = parsedExpression.getValueType(evaluationContext);
-            SqlTemplateValueType valueType = ctx.getValueTypeRegistry().findValueType(clazz, expression);
+            final Class<?> clazz = parsedExpression.getValueType(evaluationContext);
+            SqlTemplateValueType<?> valueType = ctx.getValueTypeRegistry().findValueType(clazz, expression);
+            final String sql = getEmbeddedValue(value, valueType, getPosition(), ctx.getParsedSql(), expression);
 
-            final String sql = valueType != null ? valueType.getEmbeddedValue(value) : value.toString();
             if (sql.indexOf(';') >= 0) {
                 // SQLインジェクションの原因となるセミコロンが含まれる場合は例外をスローする。
-                throw new TwoWaySqlException("semicolon is not allowed.");
+                throw new NodeProcessException(SqlUtils.resolveSqlPosition(ctx.getParsedSql(), getPosition()),
+                        String.format("Not allowed semicolon at embedded value '%s'.", sql));
             }
             ctx.addSql(sql);
         }
@@ -77,6 +78,7 @@ public class EmbeddedValueNode extends AbstractNode {
     @Override
     public String toString() {
         return new ToStringCreator(this)
+                .append("position", getPosition())
                 .append("expression", expression)
                 .append("parsedExpression", parsedExpression)
                 .append("children", children)

--- a/src/main/java/com/github/mygreen/splate/node/EmbeddedValueNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/EmbeddedValueNode.java
@@ -28,6 +28,7 @@ import lombok.Getter;
 /**
  * 値を埋め込む用の{@link Node}です
  *
+ * @version 0.2
  * @author higa
  * @author T.TSUCHIE
  */

--- a/src/main/java/com/github/mygreen/splate/node/EmbeddedValueNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/EmbeddedValueNode.java
@@ -70,7 +70,7 @@ public class EmbeddedValueNode extends AbstractNode {
             if (sql.indexOf(';') >= 0) {
                 // SQLインジェクションの原因となるセミコロンが含まれる場合は例外をスローする。
                 throw new NodeProcessException(SqlUtils.resolveSqlPosition(ctx.getParsedSql(), getPosition()),
-                        String.format("Not allowed semicolon at embedded value '%s'.", sql));
+                        String.format("Not allowed semicolon at embedded value '%s' to '%s'.", expression, sql));
             }
             ctx.addSql(sql);
         }

--- a/src/main/java/com/github/mygreen/splate/node/IfNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/IfNode.java
@@ -18,7 +18,6 @@ package com.github.mygreen.splate.node;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
-import org.springframework.expression.ExpressionParser;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -56,12 +55,12 @@ public class IfNode extends ContainerNode {
      *
      * @param position 位置情報
      * @param expression 式
-     * @param expressionParser 式のパーサ
+     * @param parsedExpression パース済みの式
      */
-    public IfNode(final int position, final String expression, final ExpressionParser expressionParser) {
+    public IfNode(final int position, final String expression, final Expression parsedExpression) {
         super(position);
         this.expression = expression;
-        this.parsedExpression = expressionParser.parseExpression(expression);
+        this.parsedExpression = parsedExpression;
     }
 
     @Override

--- a/src/main/java/com/github/mygreen/splate/node/IfNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/IfNode.java
@@ -27,6 +27,7 @@ import lombok.Setter;
 /**
  * {@code IF} コメント用の{@link Node}です。
  *
+ * @version 0.2
  * @author higa
  * @author T.TSUCHIE
  */

--- a/src/main/java/com/github/mygreen/splate/node/IfNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/IfNode.java
@@ -51,12 +51,14 @@ public class IfNode extends ContainerNode {
     private ElseNode elseNode;
 
     /**
-     * Creates n <code>IfNode</code> from a string expression.
+     * 条件式を元に、Creates {@link IfNode}を作成します。
      *
+     * @param position 位置情報
      * @param expression 式
      * @param expressionParser 式のパーサ
      */
-    public IfNode(final String expression, final ExpressionParser expressionParser) {
+    public IfNode(final int position, final String expression, final ExpressionParser expressionParser) {
+        super(position);
         this.expression = expression;
         this.parsedExpression = expressionParser.parseExpression(expression);
     }
@@ -65,7 +67,7 @@ public class IfNode extends ContainerNode {
     public void accept(final NodeProcessContext ctx) {
 
         final EvaluationContext evaluationContext = ctx.getEvaluationContext();
-        boolean result = parsedExpression.getValue(evaluationContext, boolean.class);
+        boolean result = evaluateExpression(parsedExpression, evaluationContext, boolean.class, getPosition(), ctx.getParsedSql());
 
         if (result) {
             super.accept(ctx);
@@ -79,6 +81,7 @@ public class IfNode extends ContainerNode {
     @Override
     public String toString() {
         return new ToStringCreator(this)
+                .append("position", getPosition())
                 .append("expression", expression)
                 .append("parsedExpression", parsedExpression)
                 .append("elseNode", elseNode)

--- a/src/main/java/com/github/mygreen/splate/node/Node.java
+++ b/src/main/java/com/github/mygreen/splate/node/Node.java
@@ -51,4 +51,11 @@ public interface Node {
      * @param ctx SQLテンプレートを実行するときのコンテキスト。
      */
     void accept(NodeProcessContext ctx);
+
+    /**
+     * テンプレート内での開始位置を返します。
+     *
+     * @return テンプレート内での開始位置
+     */
+    int getPosition();
 }

--- a/src/main/java/com/github/mygreen/splate/node/NodeProcessContext.java
+++ b/src/main/java/com/github/mygreen/splate/node/NodeProcessContext.java
@@ -21,14 +21,13 @@ import java.util.List;
 import org.springframework.expression.EvaluationContext;
 
 import com.github.mygreen.splate.SqlTemplateContext;
-import com.github.mygreen.splate.type.SqlTemplateValueType;
 import com.github.mygreen.splate.type.SqlTemplateValueTypeRegistry;
 
 import lombok.Getter;
 import lombok.Setter;
 
 /**
- * {@code SQLテンプレート}を価するときのコンテキストです。 コンテキストで{@code SQL}を実行するのに必要な情報を組み立てた後、
+ * {@code SQLテンプレート}を評価するときのコンテキストです。 コンテキストで{@code SQL}を実行するのに必要な情報を組み立てた後、
  * {@code getSql()}, {@code getBindVariables()},
  * {@code getBindVariableTypes()}で、 情報を取り出して{@code SQL}を実行します。
  * {@code SQL}で{@code BEGIN}コメントと{@code END}コメントで囲まれている部分が、
@@ -71,6 +70,14 @@ public class NodeProcessContext {
     private NodeProcessContext parent;
 
     /**
+     * パースされた状態のSQLテンプレート。
+     * エラー時のメッセージを出力するために使用します。
+     */
+    @Getter
+    @Setter
+    private String parsedSql;
+
+    /**
      * テンプレートパラメータなどのSQLコンテキストを指定するコンストラクタ。
      * @param templateContext SQLテンプレートのコンテキスト
      */
@@ -89,15 +96,16 @@ public class NodeProcessContext {
 
         // 各種情報の引継ぎ
         this.templateContext = parent.templateContext;
+        this.parsedSql = parent.parsedSql;
 
     }
 
     /**
-     * {@code SQL} を取得します。
+     * 処理済みの{@code SQL} を取得します。
      *
      * @return SQL
      */
-    public String getSql() {
+    public String getProcessedSql() {
         return sqlBuf.toString();
     }
 
@@ -114,17 +122,10 @@ public class NodeProcessContext {
      * {@code SQL} とバインド変数を追加します。
      * @param sql SQL
      * @param bindValue バインドする変数の値
-     * @param valueType バインドする変数のタイプに対応する {@link SqlTemplateValueType}
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public void addSql(String sql, Object bindValue, SqlTemplateValueType valueType) {
+    public void addSql(String sql, Object bindValue) {
         sqlBuf.append(sql);
-
-        if(valueType != null) {
-            bindParams.add(valueType.getBindVariableValue(bindValue));
-        } else {
-            bindParams.add(bindValue);
-        }
+        bindParams.add(bindValue);
     }
 
     /**

--- a/src/main/java/com/github/mygreen/splate/node/NodeProcessException.java
+++ b/src/main/java/com/github/mygreen/splate/node/NodeProcessException.java
@@ -1,0 +1,52 @@
+package com.github.mygreen.splate.node;
+
+import com.github.mygreen.splate.Position;
+import com.github.mygreen.splate.TwoWaySqlException;
+
+import lombok.Getter;
+
+/**
+ * SQLテンプレートを処理するときの例外です。
+ *
+ * @since 0.2
+ * @author T.TSUCHIE
+ *
+ */
+public class NodeProcessException extends TwoWaySqlException {
+
+    /**
+     * パースエラーが発生したテンプレート内での位置情報
+     */
+    @Getter
+    private final Position position;
+
+    /**
+     * メッセージと原因となったエラーを使用して新しいインスタンスを構築します。
+     *
+     * @param position パースエラーが発生したテンプレート内での位置情報
+     * @param message エラーメッセージ
+     * @param cause 原因となったエラー
+     */
+    public NodeProcessException(final Position position, String message, Throwable cause) {
+        super(message, cause);
+        this.position = position;
+    }
+
+    /**
+     * メッセージ使用して新しいインスタンスを構築します。
+     * @param position パースエラーが発生したテンプレート内での位置情報
+     * @param message エラーメッセージ
+     */
+    public NodeProcessException(final Position position, String message) {
+        super(message);
+        this.position = position;
+    }
+
+    @Override
+    public String getMessage() {
+        return super.getMessage()
+                + System.getProperty("line.separator")
+                + String.format("[row=%d, col=%d] %s", position.getRow(), position.getCol(), position.getLine());
+
+    }
+}

--- a/src/main/java/com/github/mygreen/splate/node/ParenBindVariableNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/ParenBindVariableNode.java
@@ -80,7 +80,7 @@ public class ParenBindVariableNode extends AbstractNode {
             // ただのオブジェクトの場合
             Class<?> clazz = parsedExpression.getValueType(evaluationContext);
             SqlTemplateValueType valueType = ctx.getValueTypeRegistry().findValueType(clazz, expression);
-            Object value = getBindBariableValue(var, valueType, getPosition(), ctx.getParsedSql(), expression);
+            Object value = getBindVariableValue(var, valueType, getPosition(), ctx.getParsedSql(), expression);
             ctx.addSql("?", value);
         }
 
@@ -121,13 +121,13 @@ public class ParenBindVariableNode extends AbstractNode {
         ctx.addSql("(");
         Object value = Array.get(array, 0);
         SqlTemplateValueType valueType = ctx.getValueTypeRegistry().findValueType(clazz, expression);
-        value = getBindBariableValue(value, valueType, getPosition(), ctx.getParsedSql(), expression);
+        value = getBindVariableValue(value, valueType, getPosition(), ctx.getParsedSql(), expression);
 
         ctx.addSql("?", value);
         for (int i = 1; i < length; ++i) {
             ctx.addSql(", ");
             value = Array.get(array, i);
-            value = getBindBariableValue(value, valueType, getPosition(), ctx.getParsedSql(), expression);
+            value = getBindVariableValue(value, valueType, getPosition(), ctx.getParsedSql(), expression);
             ctx.addSql("?", value);
         }
         ctx.addSql(")");

--- a/src/main/java/com/github/mygreen/splate/node/ParenBindVariableNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/ParenBindVariableNode.java
@@ -30,6 +30,7 @@ import lombok.Getter;
 /**
  * {@literal IN}のバインド変数用の{@link Node}です。
  *
+ * @version 0.2
  * @author higa
  * @author shuji.w6e
  * @author T.TSUCHIE

--- a/src/main/java/com/github/mygreen/splate/node/PrefixSqlNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/PrefixSqlNode.java
@@ -40,12 +40,14 @@ public class PrefixSqlNode extends AbstractNode {
     private final String sql;
 
     /**
-     * Creates a <code>PrefixSqlNode</code>
+     * {@link PrefixSqlNode} を作成します。
      *
+     * @param position テンプレートの位置情報
      * @param prefix プレフィックス
      * @param sql SQL
      */
-    public PrefixSqlNode(String prefix, String sql) {
+    public PrefixSqlNode(final int position, final String prefix, final String sql) {
+        super(position);
         this.prefix = prefix;
         this.sql = sql;
     }
@@ -62,9 +64,10 @@ public class PrefixSqlNode extends AbstractNode {
     @Override
     public String toString() {
         return new ToStringCreator(this)
+                .append("position", getPosition())
+                .append("children", children)
                 .append("prefix", prefix)
                 .append("sql", sql)
-                .append("children", children)
                 .toString();
     }
 }

--- a/src/main/java/com/github/mygreen/splate/node/SqlNode.java
+++ b/src/main/java/com/github/mygreen/splate/node/SqlNode.java
@@ -34,9 +34,11 @@ public class SqlNode extends AbstractNode {
 
     /**
      * SQLを指定して {@link SqlNode} を作成します。
+     * @param position テンプレートの位置情報
      * @param sql SQL
      */
-    public SqlNode(final String sql) {
+    public SqlNode(final int position, final String sql) {
+        super(position);
         this.sql = sql;
     }
 
@@ -48,8 +50,9 @@ public class SqlNode extends AbstractNode {
     @Override
     public String toString() {
         return new ToStringCreator(this)
-                .append("sql", sql)
+                .append("position", getPosition())
                 .append("children", children)
+                .append("sql", sql)
                 .toString();
     }
 }

--- a/src/main/java/com/github/mygreen/splate/parser/SqlParseException.java
+++ b/src/main/java/com/github/mygreen/splate/parser/SqlParseException.java
@@ -1,0 +1,53 @@
+package com.github.mygreen.splate.parser;
+
+import com.github.mygreen.splate.Position;
+import com.github.mygreen.splate.TwoWaySqlException;
+
+import lombok.Getter;
+
+/**
+ * SQLテンプレートのパース時のエラー。
+ *
+ * @since 0.2
+ * @author T.TSUCHIE
+ *
+ */
+public class SqlParseException extends TwoWaySqlException {
+
+    /**
+     * パースエラーが発生したテンプレート内での位置情報
+     */
+    @Getter
+    private final Position position;
+
+    /**
+     * メッセージと原因となったエラーを使用して新しいインスタンスを構築します。
+     *
+     * @param position パースエラーが発生したテンプレート内での位置情報
+     * @param message エラーメッセージ
+     * @param cause 原因となったエラー
+     */
+    public SqlParseException(final Position position, String message, Throwable cause) {
+        super(message, cause);
+        this.position = position;
+    }
+
+    /**
+     * メッセージ使用して新しいインスタンスを構築します。
+     * @param position パースエラーが発生したテンプレート内での位置情報
+     * @param message エラーメッセージ
+     */
+    public SqlParseException(final Position position, String message) {
+        super(message);
+        this.position = position;
+    }
+
+    @Override
+    public String getMessage() {
+        return super.getMessage()
+                + System.getProperty("line.separator")
+                + String.format("[row=%d, col=%d] %s", position.getRow(), position.getCol(), position.getLine());
+
+    }
+
+}

--- a/src/main/java/com/github/mygreen/splate/parser/SqlParser.java
+++ b/src/main/java/com/github/mygreen/splate/parser/SqlParser.java
@@ -263,9 +263,12 @@ public class SqlParser {
     /**
      * EL式をパースします。
      * <p>例外処理を含めて共通化のために切り出したメソッドです。</p>
+     *
+     * @since 0.2
      * @param expression 式
      * @param position テンプレート位置
      * @return パースした式
+     * @throws SqlParseException EL式のパースに失敗した場合にスローされます。
      */
     protected Expression parseExpression(final String expression, final int position) {
         try {

--- a/src/main/java/com/github/mygreen/splate/parser/SqlParser.java
+++ b/src/main/java/com/github/mygreen/splate/parser/SqlParser.java
@@ -17,10 +17,11 @@ package com.github.mygreen.splate.parser;
 
 import java.util.Stack;
 
+import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.ParseException;
 
 import com.github.mygreen.splate.SqlUtils;
-import com.github.mygreen.splate.TwoWaySqlException;
 import com.github.mygreen.splate.node.BeginNode;
 import com.github.mygreen.splate.node.BindVariableNode;
 import com.github.mygreen.splate.node.ContainerNode;
@@ -79,11 +80,19 @@ public class SqlParser {
     }
 
     /**
+     * 解析対象のSQLを取得します。
+     * @return 正規化（トリム、最後のセミコロン(;)削除）を返します。
+     */
+    public String getSql() {
+        return tokenizer.getSql();
+    }
+
+    /**
      *
      * @return SQLを解析して<code>Node</code>のツリーを返します。
      */
     public Node parse() {
-        push(new ContainerNode());
+        push(new ContainerNode(0));
         while (TokenType.EOF != tokenizer.next()) {
             parseToken();
         }
@@ -130,18 +139,18 @@ public class SqlParser {
             st.skipWhitespace();
             if (sql.startsWith(",")) {
                 if (sql.startsWith(", ")) {
-                    node.addChild(new PrefixSqlNode(", ", sql.substring(2)));
+                    node.addChild(new PrefixSqlNode(tokenizer.getPosition(), ", ", sql.substring(2)));
                 } else {
-                    node.addChild(new PrefixSqlNode(",", sql.substring(1)));
+                    node.addChild(new PrefixSqlNode(tokenizer.getPosition(), ",", sql.substring(1)));
                 }
             } else if ("AND".equalsIgnoreCase(token)
                     || "OR".equalsIgnoreCase(token)) {
-                node.addChild(new PrefixSqlNode(st.getBefore(), st.getAfter()));
+                node.addChild(new PrefixSqlNode(tokenizer.getPosition(), st.getBefore(), st.getAfter()));
             } else {
-                node.addChild(new SqlNode(sql));
+                node.addChild(new SqlNode(tokenizer.getPosition(), sql));
             }
         } else {
-            node.addChild(new SqlNode(sql));
+            node.addChild(new SqlNode(tokenizer.getPosition(), sql));
         }
     }
 
@@ -161,7 +170,7 @@ public class SqlParser {
                 parseCommentBindVariable();
             }
         } else if(isHintComment(comment)){
-            peek().addChild(new SqlNode("/*" + comment + "*/"));
+            peek().addChild(new SqlNode(tokenizer.getPosition(), "/*" + comment + "*/"));
         }
     }
 
@@ -169,11 +178,13 @@ public class SqlParser {
      * {@code IF} 句を解析します。
      */
     protected void parseIf() {
-        String condition = tokenizer.getToken().substring(2).trim();
+        final String condition = tokenizer.getToken().substring(2).trim();
+        final int position = Math.max(tokenizer.getPosition() - 2, 0);
         if (SqlUtils.isEmpty(condition)) {
-            throw new TwoWaySqlException("If condition not found.");
+            throw new SqlParseException(SqlUtils.resolveSqlPosition(tokenizer.getSql(), position),
+                    "Not found IF condition.");
         }
-        IfNode ifNode = new IfNode(condition, expressionParser);
+        IfNode ifNode = new IfNode(position, condition, expressionParser);
         peek().addChild(ifNode);
         push(ifNode);
         parseEnd();
@@ -183,7 +194,7 @@ public class SqlParser {
      * {@code BEGIN} 句を解析します。
      */
     protected void parseBegin() {
-        BeginNode beginNode = new BeginNode();
+        BeginNode beginNode = new BeginNode(tokenizer.getPosition());
         peek().addChild(beginNode);
         push(beginNode);
         parseEnd();
@@ -202,8 +213,8 @@ public class SqlParser {
             }
             parseToken();
         }
-        throw new TwoWaySqlException(String.format(
-                "END comment of %s not found.", tokenizer.getSql()));
+        throw new SqlParseException(SqlUtils.resolveSqlPosition(tokenizer.getSql(), tokenizer.getPosition()),
+                "Not found END comment.");
     }
 
     /**
@@ -215,7 +226,7 @@ public class SqlParser {
             return;
         }
         IfNode ifNode = (IfNode) pop();
-        ElseNode elseNode = new ElseNode();
+        ElseNode elseNode = new ElseNode(tokenizer.getPosition());
         ifNode.setElseNode(elseNode);
         push(elseNode);
         tokenizer.skipWhitespace();
@@ -227,14 +238,16 @@ public class SqlParser {
     protected void parseCommentBindVariable() {
         String expr = tokenizer.getToken();
         String s = tokenizer.skipToken();
+        int position = tokenizer.getPosition();
         if (s.startsWith("(") && s.endsWith(")")) {
-            peek().addChild(new ParenBindVariableNode(expr, expressionParser));
+            peek().addChild(new ParenBindVariableNode(position, expr, parseExpression(expr, position)));
         } else if (expr.startsWith("$")) {
-            peek().addChild(new EmbeddedValueNode(expr.substring(1), expressionParser));
+            expr = expr.substring(1);
+            peek().addChild(new EmbeddedValueNode(position, expr, parseExpression(expr, position)));
         } else if (expr.equalsIgnoreCase("orderBy")) {
-            peek().addChild(new EmbeddedValueNode(expr, expressionParser));
+            peek().addChild(new EmbeddedValueNode(position, expr, parseExpression(expr, position)));
         } else {
-            peek().addChild(new BindVariableNode(expr, expressionParser));
+            peek().addChild(new BindVariableNode(position, expr, parseExpression(expr, position)));
         }
     }
 
@@ -243,7 +256,25 @@ public class SqlParser {
      */
     protected void parseBindVariable() {
         String expr = tokenizer.getToken();
-        peek().addChild(new BindVariableNode(expr, expressionParser));
+        int position = tokenizer.getPosition();
+        peek().addChild(new BindVariableNode(position, expr, parseExpression(expr, position)));
+    }
+
+    /**
+     * EL式をパースします。
+     * <p>例外処理を含めて共通化のために切り出したメソッドです。</p>
+     * @param expression 式
+     * @param position テンプレート位置
+     * @return パースした式
+     */
+    protected Expression parseExpression(final String expression, final int position) {
+        try {
+            return expressionParser.parseExpression(expression);
+        } catch(ParseException e) {
+            throw new SqlParseException(SqlUtils.resolveSqlPosition(tokenizer.getSql(), position),
+                    String.format("Fail parsing expression '%s'.", expression),
+                    e);
+        }
     }
 
     /**

--- a/src/main/java/com/github/mygreen/splate/parser/SqlParser.java
+++ b/src/main/java/com/github/mygreen/splate/parser/SqlParser.java
@@ -180,7 +180,7 @@ public class SqlParser {
      */
     protected void parseIf() {
         final String condition = tokenizer.getToken().substring(2).trim();
-        final int position = Math.max(tokenizer.getPosition() - 2, 0);
+        final int position = Math.max(tokenizer.getPosition() - 2 - condition.length(), 0);
         if (SqlUtils.isEmpty(condition)) {
             throw new SqlParseException(SqlUtils.resolveSqlPosition(tokenizer.getSql(), position),
                     "Not found IF condition.");
@@ -239,11 +239,12 @@ public class SqlParser {
     protected void parseCommentBindVariable() {
         String expr = tokenizer.getToken();
         String s = tokenizer.skipToken();
-        int position = tokenizer.getPosition();
+        int position = tokenizer.getPosition() - s.length() - expr.length() -2;
         if (s.startsWith("(") && s.endsWith(")")) {
             peek().addChild(new ParenBindVariableNode(position, expr, parseExpression(expr, position)));
         } else if (expr.startsWith("$")) {
             expr = expr.substring(1);
+            position += 1;
             peek().addChild(new EmbeddedValueNode(position, expr, parseExpression(expr, position)));
         } else if (expr.equalsIgnoreCase("orderBy")) {
             peek().addChild(new EmbeddedValueNode(position, expr, parseExpression(expr, position)));

--- a/src/main/java/com/github/mygreen/splate/parser/SqlParser.java
+++ b/src/main/java/com/github/mygreen/splate/parser/SqlParser.java
@@ -185,7 +185,7 @@ public class SqlParser {
             throw new SqlParseException(SqlUtils.resolveSqlPosition(tokenizer.getSql(), position),
                     "Not found IF condition.");
         }
-        IfNode ifNode = new IfNode(position, condition, expressionParser);
+        IfNode ifNode = new IfNode(position, condition, parseExpression(condition, position));
         peek().addChild(ifNode);
         push(ifNode);
         parseEnd();

--- a/src/main/java/com/github/mygreen/splate/parser/SqlParser.java
+++ b/src/main/java/com/github/mygreen/splate/parser/SqlParser.java
@@ -37,6 +37,7 @@ import com.github.mygreen.splate.parser.SqlTokenizer.TokenType;
 /**
  * SQLを解析して<code>Node</code>のツリーにするクラスです。
  *
+ * @version 0.2
  * @author higa
  */
 public class SqlParser {

--- a/src/main/java/com/github/mygreen/splate/parser/SqlTokenizer.java
+++ b/src/main/java/com/github/mygreen/splate/parser/SqlTokenizer.java
@@ -20,6 +20,7 @@ import com.github.mygreen.splate.SqlUtils;
 /**
  * SQLをトークンに分解するクラスです。.
  *
+ * @version 0.2
  * @author higa
  */
 public class SqlTokenizer {

--- a/src/main/java/com/github/mygreen/splate/parser/SqlTokenizer.java
+++ b/src/main/java/com/github/mygreen/splate/parser/SqlTokenizer.java
@@ -15,7 +15,7 @@
  */
 package com.github.mygreen.splate.parser;
 
-import com.github.mygreen.splate.TwoWaySqlException;
+import com.github.mygreen.splate.SqlUtils;
 
 /**
  * SQLをトークンに分解するクラスです。.
@@ -36,14 +36,29 @@ public class SqlTokenizer {
         EOF
     }
 
+    /**
+     * 解析対象のSQL
+     */
     private String sql;
 
+    /**
+     * 現在解析しているポジション
+     */
     private int position = 0;
 
+    /**
+     * トークン
+     */
     private String token;
 
+    /**
+     * 現在のトークン種別
+     */
     private TokenType tokenType = TokenType.SQL;
 
+    /**
+     * 次のトークン種別
+     */
     private TokenType nextTokenType = TokenType.SQL;
 
     private int bindVariableNum = 0;
@@ -215,8 +230,8 @@ public class SqlTokenizer {
             commentEndPos = commentEndPos2;
         }
         if (commentEndPos < 0) {
-            throw new TwoWaySqlException(String.format(
-                    "%s is not closed with %s.", sql.substring(position), "*/"));
+            throw new SqlParseException(SqlUtils.resolveSqlPosition(sql, position),
+                    String.format("Not closed comment '*/' for %s.", sql.substring(position)));
         }
         token = sql.substring(position, commentEndPos);
         nextTokenType = TokenType.SQL;

--- a/src/test/java/com/github/mygreen/splate/SqlTemplateContextTest.java
+++ b/src/test/java/com/github/mygreen/splate/SqlTemplateContextTest.java
@@ -16,7 +16,6 @@ import org.springframework.core.io.ResourceLoader;
 /**
  * {@link SqlTemplateContext} のテスタ。
  *
- *
  * @author T.TSUCHIE
  *
  */
@@ -97,16 +96,16 @@ public class SqlTemplateContextTest {
 //        assertThat(result.getParameters()).containsExactly("%abc%");
 //
 //    }
-
-    /**
-     * SQLテンプレート中で利用可能なカスタム関数
-     *
-     */
-    static class SqlFunctions {
-
-        public static String contains(String value) {
-            return "%" + value + "%";
-        }
-
-    }
+//
+//    /**
+//     * SQLテンプレート中で利用可能なカスタム関数
+//     *
+//     */
+//    static class SqlFunctions {
+//
+//        public static String contains(String value) {
+//            return "%" + value + "%";
+//        }
+//
+//    }
 }

--- a/src/test/java/com/github/mygreen/splate/SqlUtilsTest.java
+++ b/src/test/java/com/github/mygreen/splate/SqlUtilsTest.java
@@ -1,0 +1,84 @@
+package com.github.mygreen.splate;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * {@link SqlUtils}のテスタ。
+ *
+ * @since 0.2
+ * @author T.TSUCHIE
+ *
+ */
+public class SqlUtilsTest extends SqlUtils {
+
+    @Test
+    void testIndexOfAny() {
+
+        assertThat(indexOfAny(null, 0, null, "a")).isEqualTo(-1);
+        assertThat(indexOfAny("abc", 0, new AtomicReference<CharSequence>(), new String[0])).isEqualTo(-1);
+
+        {
+            AtomicReference<CharSequence> foundStr = new AtomicReference<>();
+            int index = indexOfAny("zzabyycdxx", 0, foundStr, "ab", "cd");
+            assertThat(index).isEqualTo(2);
+            assertThat(foundStr.get()).isEqualTo("ab");
+        }
+
+        {
+            AtomicReference<CharSequence> foundStr = new AtomicReference<>();
+            int index = indexOfAny("zzabyycdxx", 0, foundStr, "cd", "ab");
+            assertThat(index).isEqualTo(2);
+            assertThat(foundStr.get()).isEqualTo("ab");
+        }
+
+        {
+            AtomicReference<CharSequence> foundStr = new AtomicReference<>();
+            int index = indexOfAny("zzabyycdxx", 0, foundStr, "zab", "aby");
+            assertThat(index).isEqualTo(1);
+            assertThat(foundStr.get()).isEqualTo("zab");
+        }
+
+        {
+            AtomicReference<CharSequence> foundStr = new AtomicReference<>();
+            int index = indexOfAny("zzabyycdxx", 0, foundStr, "", "abc");
+            assertThat(index).isEqualTo(0);
+            assertThat(foundStr.get()).isEqualTo("");
+        }
+
+    }
+
+    @Test
+    void testResolveSqlPosition() {
+
+        String sql = "SELECT * "
+                + "\r\n" + " FROM"
+                + "\r\n" + " EMPLOYEE"
+                + "\r\n" + " WHERE"
+                + "\r\n" + "  /*IF id != null*/"
+                + "\r\n" + "  id = /*id*/10"
+                + "\r\n" + "  /*END*/"
+                ;
+
+        {
+            // 先頭行
+            Position result = resolveSqlPosition(sql, 7);
+            assertThat(result.getRow()).isEqualTo(1);
+            assertThat(result.getCol()).isEqualTo(7);
+            assertThat(result.getLine()).isEqualTo("SELECT * ");
+        }
+
+        {
+            // 行の途中
+            Position result = resolveSqlPosition(sql, 46);
+            assertThat(result.getRow()).isEqualTo(5);
+            assertThat(result.getCol()).isEqualTo(8);
+            assertThat(result.getLine()).isEqualTo("  /*IF id != null*/");
+        }
+
+    }
+}

--- a/src/test/java/com/github/mygreen/splate/parse/SqlParserTest.java
+++ b/src/test/java/com/github/mygreen/splate/parse/SqlParserTest.java
@@ -230,6 +230,21 @@ public class SqlParserTest {
     }
 
     @Test
+    public void testEmbeddedValue_semicolon() {
+
+        String sql = "SELECT * FROM emp limit /*$limit*/10 offset /*$offset*/5";
+
+        SqlTemplate template = templateEngine.getTemplateByText(sql);
+        SqlTemplateContext context = new MapSqlTemplateContext(Map.of("limit", 100, "offset", ";update"));
+
+        assertThatThrownBy(() -> template.process(context))
+            .isInstanceOf(NodeProcessException.class)
+            .hasMessageContaining("Not allowed semicolon at embedded value 'offset' to ';update'.")
+            .hasFieldOrPropertyWithValue("position", new Position(1, 47, sql));
+
+    }
+
+    @Test
     public void testEmbeddedValue_evalELError() {
 
         String sql = "SELECT * FROM emp limit /*$limit*/10 offset /*$offset*/5";

--- a/src/test/java/com/github/mygreen/splate/type/EnumNameType.java
+++ b/src/test/java/com/github/mygreen/splate/type/EnumNameType.java
@@ -1,0 +1,18 @@
+package com.github.mygreen.splate.type;
+
+/**
+ * 列挙型の変換規則。
+ *  nameに変換する。
+ *
+ *
+ * @author T.TSUCHIE
+ *
+ */
+public class EnumNameType<T extends Enum<T>> implements SqlTemplateValueType<T> {
+
+    @Override
+    public Object getBindVariableValue(T value) throws SqlTypeConversionException {
+        String sqlValue = (value != null ? value.name() : null);
+        return sqlValue;
+    }
+}

--- a/src/test/java/com/github/mygreen/splate/type/EnumOrdinalType.java
+++ b/src/test/java/com/github/mygreen/splate/type/EnumOrdinalType.java
@@ -1,0 +1,18 @@
+package com.github.mygreen.splate.type;
+
+/**
+ * 列挙型の変換規則。
+ * ordinalに変換する。
+ *
+ *
+ * @author T.TSUCHIE
+ *
+ */
+public class EnumOrdinalType<T extends Enum<T>> implements SqlTemplateValueType<T> {
+
+    @Override
+    public Object getBindVariableValue(T value) throws SqlTypeConversionException {
+        Integer sqlValue = (value != null ? value.ordinal() : null);
+        return sqlValue;
+    }
+}

--- a/src/test/java/com/github/mygreen/splate/type/JobType.java
+++ b/src/test/java/com/github/mygreen/splate/type/JobType.java
@@ -1,0 +1,16 @@
+package com.github.mygreen.splate.type;
+
+
+/**
+ * テスト用の列挙型
+ *
+ *
+ */
+public enum JobType {
+    /**店員*/
+    CLERK,
+    /**調理師*/
+    COOKS,
+    /**オーナー*/
+    OWNER
+}

--- a/src/test/java/com/github/mygreen/splate/type/LocalDateType.java
+++ b/src/test/java/com/github/mygreen/splate/type/LocalDateType.java
@@ -1,0 +1,20 @@
+package com.github.mygreen.splate.type;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+/**
+ * {@link LocalDate} の変換規則。
+ *
+ * @since 0.2
+ * @author T.TSUCHIE
+ *
+ */
+public class LocalDateType implements SqlTemplateValueType<LocalDate> {
+
+    @Override
+    public Object getBindVariableValue(LocalDate value) throws SqlTypeConversionException {
+        Date sqlValue = (value != null ? Date.valueOf(value) : null);
+        return sqlValue;
+    }
+}

--- a/src/test/java/com/github/mygreen/splate/type/SqlTemplateValueTypeRegistryTest.java
+++ b/src/test/java/com/github/mygreen/splate/type/SqlTemplateValueTypeRegistryTest.java
@@ -27,26 +27,6 @@ public class SqlTemplateValueTypeRegistryTest {
         this.registry = new SqlTemplateValueTypeRegistry();
     }
 
-    private static class LocalDateType implements SqlTemplateValueType<LocalDate> {
-
-        @Override
-        public Object getBindVariableValue(LocalDate value) throws SqlTypeConversionException {
-            Date sqlValue = (value != null ? Date.valueOf(value) : null);
-            return sqlValue;
-        }
-
-    }
-
-    private static class EnumOrdinalType<T extends Enum<T>> implements SqlTemplateValueType<T> {
-
-        @Override
-        public Object getBindVariableValue(T value) throws SqlTypeConversionException {
-            Integer sqlValue = (value != null ? value.ordinal() : null);
-            return sqlValue;
-        }
-
-    }
-
     private enum Color {
         BLUE, RED, YELLOW;
     }

--- a/src/test/java/com/github/mygreen/splate/type/SqlTemplateValueTypeTest.java
+++ b/src/test/java/com/github/mygreen/splate/type/SqlTemplateValueTypeTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.github.mygreen.splate.MapSqlTemplateContext;
+import com.github.mygreen.splate.Position;
 import com.github.mygreen.splate.ProcessResult;
 import com.github.mygreen.splate.SqlTemplate;
 import com.github.mygreen.splate.SqlTemplateContext;
@@ -93,7 +94,8 @@ public class SqlTemplateValueTypeTest {
         assertThatThrownBy(() -> template.process(context))
             .isInstanceOf(NodeProcessException.class)
             .hasCauseInstanceOf(SqlTypeConversionException.class)
-            .hasMessageContaining("Fail converting value of expression 'job'.");
+            .hasMessageContaining("Fail converting value of expression 'job'.")
+            .hasFieldOrPropertyWithValue("position", new Position(1, 32, sql));
 
     }
 
@@ -122,7 +124,8 @@ public class SqlTemplateValueTypeTest {
         assertThatThrownBy(() -> template.process(context))
             .isInstanceOf(NodeProcessException.class)
             .hasCauseInstanceOf(SqlTypeConversionException.class)
-            .hasMessageContaining("Fail converting value of expression 'job'.");
+            .hasMessageContaining("Fail converting value of expression 'job'.")
+            .hasFieldOrPropertyWithValue("position", new Position(1, 33, sql));
 
     }
 
@@ -151,6 +154,7 @@ public class SqlTemplateValueTypeTest {
         assertThatThrownBy(() -> template.process(context))
             .isInstanceOf(NodeProcessException.class)
             .hasCauseInstanceOf(TextConversionException.class)
-            .hasMessageContaining("Fail converting value of expression 'job'.");
+            .hasMessageContaining("Fail converting value of expression 'job'.")
+            .hasFieldOrPropertyWithValue("position", new Position(1, 33, sql));
     }
 }

--- a/src/test/java/com/github/mygreen/splate/type/SqlTemplateValueTypeTest.java
+++ b/src/test/java/com/github/mygreen/splate/type/SqlTemplateValueTypeTest.java
@@ -29,15 +29,6 @@ public class SqlTemplateValueTypeTest {
 
     private SqlTemplateEngine templateEngine;
 
-    enum JobType {
-        /**店員*/
-        CLERK,
-        /**調理師*/
-        COOKS,
-        /**オーナー*/
-        OWNER
-    }
-
     private static class JobValueType implements SqlTemplateValueType<JobType>{
 
         @Override
@@ -76,6 +67,20 @@ public class SqlTemplateValueTypeTest {
         SqlTemplate template = templateEngine.getTemplateByText(sql);
         SqlTemplateContext context = new MapSqlTemplateContext(Map.of("job", JobType.COOKS));
         context.registerValueType(JobType.class, new JobValueType());
+
+        ProcessResult result = template.process(context);
+
+        assertThat(result.getSql()).isEqualTo("SELECT * FROM emp WHERE job = ?");
+        assertThat(result.getParameters()).containsExactly(1);
+    }
+
+    @Test
+    void testBindVariableNode_path() {
+        String sql = "SELECT * FROM emp WHERE job = /*job*/'CLERK'";
+
+        SqlTemplate template = templateEngine.getTemplateByText(sql);
+        SqlTemplateContext context = new MapSqlTemplateContext(Map.of("job", JobType.COOKS));
+        context.registerValueType("job", JobType.class, new JobValueType());
 
         ProcessResult result = template.process(context);
 

--- a/src/test/java/com/github/mygreen/splate/type/SqlTemplateValueTypeTest.java
+++ b/src/test/java/com/github/mygreen/splate/type/SqlTemplateValueTypeTest.java
@@ -10,15 +10,17 @@ import org.junit.jupiter.api.Test;
 
 import com.github.mygreen.splate.MapSqlTemplateContext;
 import com.github.mygreen.splate.ProcessResult;
-import com.github.mygreen.splate.SqlTemplateContext;
 import com.github.mygreen.splate.SqlTemplate;
+import com.github.mygreen.splate.SqlTemplateContext;
 import com.github.mygreen.splate.SqlTemplateEngine;
+import com.github.mygreen.splate.node.NodeProcessException;
 
 
 /**
  * 各ノードの{@link SqlTemplateValueType} による変換処理の実装のテスタ。
  *
  *
+ * @version 0.2
  * @author T.TSUCHIE
  *
  */
@@ -43,6 +45,24 @@ public class SqlTemplateValueTypeTest {
         }
     }
 
+    /**
+     * 必ず例外をスローする。
+     * @since 0.2
+     *
+     */
+    private static class ErrorJobValueType implements SqlTemplateValueType<JobType>{
+
+        @Override
+        public Object getBindVariableValue(JobType value) throws SqlTypeConversionException {
+            throw new SqlTypeConversionException(value, "fail conversion");
+        }
+
+        @Override
+        public String getEmbeddedValue(JobType value) throws TextConversionException {
+            throw new TextConversionException(value, "fail conversion");
+        }
+    }
+
     @BeforeEach
     void setUp() throws Exception {
         this.templateEngine = new SqlTemplateEngine();
@@ -63,6 +83,21 @@ public class SqlTemplateValueTypeTest {
     }
 
     @Test
+    void testBindVariableNode_failConversion() {
+        String sql = "SELECT * FROM emp WHERE job = /*job*/'CLERK'";
+
+        SqlTemplate template = templateEngine.getTemplateByText(sql);
+        SqlTemplateContext context = new MapSqlTemplateContext(Map.of("job", JobType.COOKS));
+        context.registerValueType(JobType.class, new ErrorJobValueType());
+
+        assertThatThrownBy(() -> template.process(context))
+            .isInstanceOf(NodeProcessException.class)
+            .hasCauseInstanceOf(SqlTypeConversionException.class)
+            .hasMessageContaining("Fail converting value of expression 'job'.");
+
+    }
+
+    @Test
     void testParenBindVariableNode() {
         String sql = "SELECT * FROM emp WHERE job in /*job*/('CLERK', 'COOKS')";
 
@@ -77,6 +112,21 @@ public class SqlTemplateValueTypeTest {
     }
 
     @Test
+    void testParenBindVariableNode_failConversion() {
+        String sql = "SELECT * FROM emp WHERE job in /*job*/('CLERK', 'COOKS')";
+
+        SqlTemplate template = templateEngine.getTemplateByText(sql);
+        SqlTemplateContext context = new MapSqlTemplateContext(Map.of("job", List.of(JobType.COOKS, JobType.OWNER)));
+        context.registerValueType(JobType.class, new ErrorJobValueType());
+
+        assertThatThrownBy(() -> template.process(context))
+            .isInstanceOf(NodeProcessException.class)
+            .hasCauseInstanceOf(SqlTypeConversionException.class)
+            .hasMessageContaining("Fail converting value of expression 'job'.");
+
+    }
+
+    @Test
     void testEmbeddedValueNode() {
         String sql = "SELECT * FROM emp WHERE job = /*$job*/'CLERK'";
 
@@ -88,5 +138,19 @@ public class SqlTemplateValueTypeTest {
 
         assertThat(result.getSql()).isEqualTo("SELECT * FROM emp WHERE job = COOKS");
         assertThat(result.getParameters()).isEmpty();
+    }
+
+    @Test
+    void testEmbeddedValueNode_failConversion() {
+        String sql = "SELECT * FROM emp WHERE job = /*$job*/'CLERK'";
+
+        SqlTemplate template = templateEngine.getTemplateByText(sql);
+        SqlTemplateContext context = new MapSqlTemplateContext(Map.of("job", JobType.COOKS));
+        context.registerValueType(JobType.class, new ErrorJobValueType());
+
+        assertThatThrownBy(() -> template.process(context))
+            .isInstanceOf(NodeProcessException.class)
+            .hasCauseInstanceOf(TextConversionException.class)
+            .hasMessageContaining("Fail converting value of expression 'job'.");
     }
 }


### PR DESCRIPTION
次の処理にて、テンプレート位置情報（行番号、列番号、該当行）を出力するよう変更。

- テンプレートの位置情報を例外に含める処理。
  - SQLのテンプレートのパース時
  - SQLの評価時
    - EL式の評価時
    - 値の変換時
- 例外を機能単位に追加。
  - SqlTemplateParseException : SQLのパース時の例外
  - NodeProcessException : SQLの評価時の例外

## エラーのサンプル
エラーメッセージに、テンプレートの行(row)、列(col)と問題の行を出力する。

```
com.github.mygreen.splate.parser.SqlParseException: Fail parsing expression 'salaryMin
/*END'.; nested exception is org.springframework.expression.spel.SpelParseException: Expression [salaryMin
/*END] @11: EL1042E: Problem parsing right operand
[row=5, col=11] salary >= /*salaryMin
	at com.github.mygreen.splate.parser.SqlParser.parseExpression(SqlParser.java:279)
	at com.github.mygreen.splate.parser.SqlParser.parseCommentBindVariable(SqlParser.java:252)
```